### PR TITLE
Update service.rb

### DIFF
--- a/lib/unitpay/service.rb
+++ b/lib/unitpay/service.rb
@@ -24,6 +24,7 @@ module Unitpay
     end
 
     def valid_action_signature?(method, params)
+      return false if params.nil? || params[:signature].nil?
       params[:signature] == calculate_action_sign(method, params)
     end
 


### PR DESCRIPTION
Fix error: undefined method `[]' for nil:NilClass

If nil params or params[:signature]
This scenario is possible, when the called notify method without parameters, for example, in tests
